### PR TITLE
fix: don't allow ABORT to kill future assets

### DIFF
--- a/public/emHdBindings.js
+++ b/public/emHdBindings.js
@@ -916,7 +916,7 @@ var getUsdModule = ((args) => {
       }
       what = "Aborted(" + what + ")";
       err(what);
-      ABORT = true;
+      // ABORT = true; // this does not allow anything to work after being set, however we're actually okay to try other assets so we shouldn't do this
       EXITSTATUS = 1;
       what += ". Build with -sASSERTIONS for more info.";
       var e = new WebAssembly.RuntimeError(what);


### PR DESCRIPTION
Not positive that this is the best way to solve this, I don't see any build flags to be able to do this at build time. This ABORT flag makes it so that no user callbacks or asyncified functions are run anymore