### PR TITLE
feat: added support for switching variants

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -24,6 +24,10 @@ body {
   margin-bottom:15px;
 }
 
+.hidden {
+    display: none!important;
+}
+
 #message-log {
   opacity:0.5;
   font-size:0.75em;

--- a/public/index.html
+++ b/public/index.html
@@ -52,16 +52,34 @@
 
     <a id="export-gltf">Export as .glb</a></button>
     <br/>
-  </div>
-  <div class="buttons">
-    <a href="https://github.com/usd-wg/assets">usd-wg/assets</a>
-    <a class="file" href="?file=https://github.com/usd-wg/assets/blob/main/full_assets/Teapot/Teapot.usd">Teapot</a>
-    <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/McUsd/McUsd.usda">McUsd</a>
-    <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/CarbonFrameBike/index.usda">Bike .usda</a>
-    <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/CarbonFrameBike/CarbonFrameBike.usdz">Bike .usdz</a>
-    <a class="file" href="?file=https://github.com/usd-wg/assets/blob/main/full_assets/Vehicles/USD_Mini_Car_Kit/assets/vehicles/vehicleVariants.usda">Vehicles</a>
-    <a class="file" href="?file=https://cloud-staging.needle.tools/-/assets/Z23hmXBZCdB4p-ZCdB4p/file.usdz">Kitchen Set</a>
-  </div>
+    </div>
+    <div class="buttons">
+      <a href="https://github.com/usd-wg/assets">usd-wg/assets</a>
+      <a class="file" href="?file=https://github.com/usd-wg/assets/blob/main/full_assets/Teapot/Teapot.usd">Teapot</a>
+      <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/McUsd/McUsd.usda">McUsd</a>
+      <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/CarbonFrameBike/index.usda">Bike .usda</a>
+      <a class="file" href="?file=https://github.com/usd-wg/assets/blob/jcowles/discoverability/full_assets/CarbonFrameBike/CarbonFrameBike.usdz">Bike .usdz</a>
+      <a class="file" href="?file=https://github.com/usd-wg/assets/blob/main/full_assets/Vehicles/USD_Mini_Car_Kit/assets/vehicles/vehicleVariants.usda">Vehicles</a>
+      <a class="file" href="?file=https://cloud-staging.needle.tools/-/assets/Z23hmXBZCdB4p-ZCdB4p/file.usdz">Kitchen Set</a>
+    </div>
+
+    <br/>
+
+    <div class="buttons hidden" id="variantInfo">
+      <a>
+        <label for="defaultPrim">Default Prim:</label>
+        <span id="defaultPrim"></span>
+      </a>
+      <a>
+        <label for="variantSet">Variant Set:</label>
+        <span id="variantSet"></span>
+      </a>
+      <a>
+        <label for="variantOptions">Active Variant:</label>
+        <select id="variantOptions"></select>
+      </a>
+    </div>
+
     
     <p id="message-log">
       Waiting for initialization to start...

--- a/public/index.js
+++ b/public/index.js
@@ -246,6 +246,7 @@ async function loadUsdFile(directory, filename, path, isRootFile = true) {
   fitCameraToSelection(window.camera, window._controls, [window.usdRoot]);
   console.log("Loading done. Scene: ", window.usdRoot);
 
+
   const defaultPrimName = window.usdStage.GetRootLayer().GetDefaultPrim();
   document.getElementById('defaultPrim').textContent = defaultPrimName;
 
@@ -282,6 +283,8 @@ async function loadUsdFile(directory, filename, path, isRootFile = true) {
     variantInfo.classList.add('hidden');
   }
 
+  fitCameraToSelection(window.camera, window._controls, [window.usdRoot]);
+  console.log("Loading done. Scene: ", window.usdRoot);
   ready = true;
   try {
     console.log("Currently Exposed API", {

--- a/usd-wasm/src/bindings/emHdBindings.js
+++ b/usd-wasm/src/bindings/emHdBindings.js
@@ -8065,7 +8065,7 @@ var getUsdModule = ((args) => {
       nb: ___cxa_get_exception_ptr,
       Ua: ___cxa_rethrow,
       Bc: ___cxa_rethrow_primary_exception,
-      y: ___cxa_throw,
+      z: ___cxa_throw,
       Cc: ___cxa_uncaught_exceptions,
       Rc: ___emscripten_init_main_thread_js,
       bb: ___emscripten_thread_cleanup,
@@ -8093,8 +8093,8 @@ var getUsdModule = ((args) => {
       H: __embind_register_class,
       da: __embind_register_class_class_function,
       wa: __embind_register_class_class_property,
-      N: __embind_register_class_constructor,
-      z: __embind_register_class_function,
+      M: __embind_register_class_constructor,
+      y: __embind_register_class_function,
       x: __embind_register_class_property,
       fd: __embind_register_emval,
       sb: __embind_register_enum,
@@ -8190,7 +8190,7 @@ var getUsdModule = ((args) => {
       aa: invoke_iidiii,
       vd: invoke_iidiiii,
       Za: invoke_iidiiiii,
-      M: invoke_iif,
+      N: invoke_iif,
       ta: invoke_iiffi,
       id: invoke_iifi,
       e: invoke_iii,
@@ -10300,8 +10300,8 @@ var getUsdModule = ((args) => {
       (_asyncify_start_rewind = wasmExports["Ug"])(a0);
     var _asyncify_stop_rewind = () =>
       (_asyncify_stop_rewind = wasmExports["Vg"])();
-    var ___start_em_js = (Module["___start_em_js"] = 3888140);
-    var ___stop_em_js = (Module["___stop_em_js"] = 3892185);
+    var ___start_em_js = (Module["___start_em_js"] = 3894380);
+    var ___stop_em_js = (Module["___stop_em_js"] = 3895704);
     function invoke_iii(index, a1, a2) {
       var sp = stackSave();
       try {


### PR DESCRIPTION
- built a new wasm version with variant related functions
- optionally show a new line of information in the header if the asset has variants to show the default prim, top / first variant set, and the top / first variant set options
- await loading and drawing and setting a variant as it can trigger a fetch which can freeze the page
- wasm file grew because of removing asyncify_remove, not worth it to continuously break the page on new functionality, will revisit later