### PR TITLE
Fix: Drop usd File cause "Usd is not defined" Error

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -518,8 +518,8 @@ async function loadFile(fileOrHandle, isRootFile = true, fullPath = undefined) {
         directory = fullPath.substring(0, fullPath.length - fileName.length);
         if (debugFileHandling) console.warn("directory", directory, "fileName", fileName);
       }
-      Usd.FS_createPath("", directory, true, true);
-      Usd.FS_createDataFile(directory, fileName, new Uint8Array(event.target.result), true, true, true);
+      USD.FS_createPath("", directory, true, true);
+      USD.FS_createDataFile(directory, fileName, new Uint8Array(event.target.result), true, true, true);
 
       loadUsdFile(directory, fileName, fullPath, isRootFile);
     };


### PR DESCRIPTION
It's more likely Forgot to change `Usd` to `USD`